### PR TITLE
Update action to use faraday 1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl https://stedolan.github.io/jq/download/linux64/jq > /usr/bin/jq && chmo
 
 FROM ruby:3-slim-buster
 
-RUN gem install faraday -v 1.6.0 && gem install octokit
+RUN gem install faraday -v 1.7.0 && gem install octokit
 
 COPY notify-pr.sh /notify-pr.sh
 RUN chmod +x notify-pr.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN go build -o /message .
 RUN curl https://stedolan.github.io/jq/download/linux64/jq > /usr/bin/jq && chmod +x /usr/bin/jq
 
 FROM ruby:3-slim-buster
-RUN gem install octokit
+
+RUN gem install faraday -v 1.6.0 && gem install octokit
 
 COPY notify-pr.sh /notify-pr.sh
 RUN chmod +x notify-pr.sh

--- a/notify-pr.sh
+++ b/notify-pr.sh
@@ -19,7 +19,7 @@ json = File.read(ENV.fetch("GITHUB_EVENT_PATH"))
 event = JSON.parse(json)
 pr = event["number"]
 
-github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+github = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
 comments = github.issue_comments(repo, pr)
 comment = comments.find { |c| c["body"].start_with?("Your preview environment") }
 


### PR DESCRIPTION
Faraday 1.7.1 adds a deprecation warning. Until octokit fixes issue https://github.com/octokit/octokit.rb/issues/1357, I think it's better for us to pin to 1.7.0 (the version before the warnings) to avoid having warnings that might confuse our users.