### PR TITLE
Include .crt extension to the certificate file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ fi
 
 if [ ! -z "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
-   echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert
+   echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert.crt
    update-ca-certificates
 fi
 


### PR DESCRIPTION
A customer reported that the certificate without the `.crt` extension wasn't being considered. Taking a look to the documentation, it seems the extension should be included

![Captura de pantalla 2022-02-10 a las 8 59 42](https://user-images.githubusercontent.com/3510171/153365487-99c2ab4a-ac37-44e5-a3db-854376d765f6.png)
