### PR TITLE
fix: logs leaking from internal dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl https://stedolan.github.io/jq/download/linux64/jq > /usr/bin/jq && chmo
 
 FROM ruby:3-slim-buster
 
-RUN gem install faraday -v 1.7.0 && gem install octokit
+RUN gem install octokit
 
 COPY notify-pr.sh /notify-pr.sh
 RUN chmod +x notify-pr.sh


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes https://github.com/okteto/okteto/issues/1731

They already merged the open issue here https://github.com/octokit/octokit.rb/pull/1359

