### PR TITLE
Backport #44 into v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go env -w GO111MODULE=off
 RUN go get github.com/machinebox/graphql
 COPY message.go .
 RUN go build -o /message .
-RUN curl https://stedolan.github.io/jq/download/linux64/jq > /usr/bin/jq && chmod +x /usr/bin/jq
+RUN curl -L https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 > /usr/bin/jq && chmod +x /usr/bin/jq
 
 FROM ruby:3-slim-buster
 


### PR DESCRIPTION
fix: jq url in v2 branch
(cherry picked from commit 35539ae158204edff3d28c420f317240942ab303)

