### PR TITLE
Skip PR notification if not required

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,8 +66,12 @@ echo running: okteto preview deploy $name --scope $scope --branch="${branch}" --
 ret=0
 okteto preview deploy $name --scope $scope --branch="${branch}" --repository="${GITHUB_SERVER_URL}/${repository}" --sourceUrl="${GITHUB_SERVER_URL}/${repository}/pull/${number}" ${params} --wait || ret=1
 
-if [ ! -z $GITHUB_TOKEN ]; then
-  withErrors="preview deployed with resource errors"
+if [ -z "$number" ] || [ "$number" = "null" ]; then
+  echo "No pull-request defined, skipping notification."
+  exit 0
+fi
+
+if [ -n "$GITHUB_TOKEN" ]; then
   if [ $ret = 1 ]; then
     message=$(/message $name 1)
   else


### PR DESCRIPTION
Fixes: https://github.com/okteto/app/issues/6709

## Description

Currently this action successfully deploys the preview environment, but it returns a non-zero exit code when using `repository_dispatch` if the payload does not send a PR number.

In most of scenarios there will be a PR, but given the nature of `repository_dispatch`, it allows invoking the deployment from GitHub's API and not necessarily from a PR. 

If the PR number is not defined, the notification (automated comment) should be skipped.

## Testing done

1. Using a [test repo](https://github.com/andreafalzetti/k8s-status-api/), I've configured a GHA workflow to use this action (on this specific branch)
2. I've tested the `pull_request` approach, and it keeps working as expected: [see logs](https://github.com/andreafalzetti/k8s-status-api/actions/runs/5315518580/jobs/9623979706#step:5:162) and notice the [PR being commented](https://github.com/andreafalzetti/k8s-status-api/pull/7#issuecomment-1597669936).
3. I've tested the `repository_dispatch` approach with 2 different payloads:
    a. with PR: [see logs](https://github.com/andreafalzetti/k8s-status-api/actions/runs/5315549768/jobs/9624046019#step:5:162) -> Notice in the logs: `Message already exists in the PR. Updating` (I've passed the number 7 which is the same PR opened to test `pull_request`).
    b. without PR: [see logs](https://github.com/andreafalzetti/k8s-status-api/actions/runs/5315535950/jobs/9624015768#step:5:161) -> notice in the logs: `No pull-request defined, skipping notification.`

For caling GitHub's API and trigger a `repository_dispatch`, I wrote this script:

```bash
#!/bin/bash

# Check if GITHUB_TOKEN is set
if [[ -z "${GITHUB_TOKEN}" ]]; then
  echo "Please set the GITHUB_TOKEN environment variable"
  exit 1
fi

if [ $# -lt 2 ]; then
    echo "Usage: $0 <owner> <repo> [pull-request-number]"
    exit 1
fi

OWNER=$1
REPO=$2
PR_NUMBER=$3

TIMESTAMP=$(date +%s)

if [ -n "$PR_NUMBER" ]; then
    PAYLOAD="{\"event_type\": \"deploy-preview\", \"client_payload\": { \"pull_request\": { \"number\": \"$PR_NUMBER\" }, \"inputs\": { \"name\": \"env-$TIMESTAMP\" } }}"
else
    PAYLOAD="{\"event_type\": \"deploy-preview\", \"client_payload\": { \"inputs\": { \"name\": \"env-$TIMESTAMP\" } }}"
fi

curl -XPOST -H "Authorization: token $GITHUB_TOKEN" \
    -H "Accept: application/vnd.github.everest-preview+json" \
    "https://api.github.com/repos/$OWNER/$REPO/dispatches" \
    --data "$PAYLOAD"
```

**Usage:**

```
GITHUB_TOKEN=*** ./repo-dispatch.sh <owner> <repo> <pull-request-number (optional)>
```