### PR TITLE
feat: add branch parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ A list of variables to be used by the pipeline. If several variables are present
 
 Relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml).
 
+### `branch`
+
+The branch to use for the preview environment (defaults to the branch that triggered the action).
+
 ## Environment Variables
 
 If the `GITHUB_TOKEN` environment variable is set, the action will share the URL of the preview environment with the pull request that triggered the action.

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   file:
     description: "Path to the manifest file"
     required: false
+  branch:
+    description: "The branch to deploy"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -26,6 +29,7 @@ runs:
     - ${{ inputs.scope }}
     - ${{ inputs.variables }}
     - ${{ inputs.file }}
+    - ${{ inputs.branch }}
 branding:
   color: 'green'
   icon: 'grid'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ timeout=$2
 scope=$3
 variables=$4
 file=$5
-
+branch=$6
 
 if [ -z $name ]; then
   echo "Preview environment name is required"
@@ -17,26 +17,26 @@ if [ -z $scope ]; then
   scope=personal
 fi
 
-
 if [ ! -z "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
    echo "$OKTETO_CA_CERT" > /usr/local/share/ca-certificates/okteto_ca_cert.crt
    update-ca-certificates
 fi
 
-if [ -z $GITHUB_REF ]; then
-echo "fail to detect branch name"
-exit 1
+if [ -z "$branch" ]; then
+  if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+    branch=${GITHUB_HEAD_REF}
+  else
+    branch=${GITHUB_REF#refs/heads/}
+  fi
+fi
+
+if [ -z "$branch" ]; then
+  echo "fail to detect branch name"
+  exit 1
 fi
 
 repository=$GITHUB_REPOSITORY
-
-if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-  branch=${GITHUB_HEAD_REF}
-else
-  branch=$(echo ${GITHUB_REF#refs/heads/})
-fi
-
 
 if [ ! -z $timeout ]; then
 params="${params} --timeout=$timeout"


### PR DESCRIPTION
This PR adds a parameter `branch` for those use-cases where the auto-detection of the branch name might not work.

To validate the change, I've used this feature branch as GHA of a personal repository using the `deploy-preview` action.

In [this execution](https://github.com/andreafalzetti/k8s-status-api/actions/runs/8192168965/job/22403093057#step:5:11) I've specified `branch: non-existing-branch` as part of the action params and from the logs we can see `--branch=non-existing-branch`.

In the [following execution]() I've removed the `branch` param and from the logs we can see the branch is detected as expected (`--branch=af/test-preview`). Note `af/test-preview` is the branch used for the tests)

Note: if `branch` is specified, we never attempt to detect it. This means that for Pull Requests events, too, if `branch` is provided, we use the one provided.

To test the Pull Request events, see [this execution](https://github.com/andreafalzetti/k8s-status-api/actions/runs/8192413975/job/22403842450#step:5:11).