### PR TITLE
Add debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The branch to use for the preview environment (defaults to the branch that trigg
 
 ### `log-level`
 
-Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to `warn`)
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ Relative path within the repository to the manifest file (default to okteto-pipe
 
 The branch to use for the preview environment (defaults to the branch that triggered the action).
 
-### `debug`
+### `log-level`
 
-Enable debug logging. (defaults to false). 
-You can re-run a worflow and (enable debug logging from the dialog)[https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging].
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Relative path within the repository to the manifest file (default to okteto-pipe
 
 The branch to use for the preview environment (defaults to the branch that triggered the action).
 
+### `debug`
+
+Enable debug logging. (defaults to false). 
+You can re-run a worflow and (enable debug logging from the dialog)[https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging].
+
 ## Environment Variables
 
 If the `GITHUB_TOKEN` environment variable is set, the action will share the URL of the preview environment with the pull request that triggered the action.

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
   branch:
     description: "The branch to deploy"
     required: false
-  debug:
-    description: "Enable debug log level when running the action"
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
     required: false
 runs:
   using: "docker"
@@ -33,7 +33,7 @@ runs:
     - ${{ inputs.variables }}
     - ${{ inputs.file }}
     - ${{ inputs.branch }}
-    - ${{ inputs.debug }}
+    - ${{ inputs.log-level }}
 branding:
   color: 'green'
   icon: 'grid'

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   branch:
     description: "The branch to deploy"
     required: false
+  debug:
+    description: "Enable debug log level when running the action"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -30,6 +33,7 @@ runs:
     - ${{ inputs.variables }}
     - ${{ inputs.file }}
     - ${{ inputs.branch }}
+    - ${{ inputs.debug }}
 branding:
   color: 'green'
   icon: 'grid'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,8 @@ fi
 
 if [ "$debug" = "true" ]; then
   debug="-l debug"
+elif [ "${ACTIONS_STEP_DEBUG}" = "true" ]; then
+  debug="-l debug"
 else
   debug=""
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,9 +63,15 @@ elif [ "${GITHUB_EVENT_NAME}" = "repository_dispatch" ]; then
   number=$(jq '[ .client_payload.pull_request.number ][0]' $GITHUB_EVENT_PATH)
 fi
 
-echo running: okteto preview deploy $name --scope $scope --branch="${branch}" --repository="${GITHUB_SERVER_URL}/${repository}" --sourceUrl="${GITHUB_SERVER_URL}/${repository}/pull/${number}" ${params} --wait
+if [ "$debug" = "true" ]; then
+  debug="-l debug"
+else
+  debug=""
+fi
+
+echo running: okteto preview deploy $name $debug --scope $scope --branch="${branch}" --repository="${GITHUB_SERVER_URL}/${repository}" --sourceUrl="${GITHUB_SERVER_URL}/${repository}/pull/${number}" ${params} --wait
 ret=0
-okteto preview deploy $name --scope $scope --branch="${branch}" --repository="${GITHUB_SERVER_URL}/${repository}" --sourceUrl="${GITHUB_SERVER_URL}/${repository}/pull/${number}" ${params} --wait || ret=1
+okteto preview deploy $name $debug --scope $scope --branch="${branch}" --repository="${GITHUB_SERVER_URL}/${repository}" --sourceUrl="${GITHUB_SERVER_URL}/${repository}/pull/${number}" ${params} --wait || ret=1
 
 if [ -z "$number" ] || [ "$number" = "null" ]; then
   echo "No pull-request defined, skipping notification."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ scope=$3
 variables=$4
 file=$5
 branch=$6
+debug=$7
 
 if [ -z $name ]; then
   echo "Preview environment name is required"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ fi
 
 if [ "$debug" = "true" ]; then
   debug="-l debug"
-elif [ "${ACTIONS_STEP_DEBUG}" = "true" ]; then
+elif [ "${RUNNER_DEBUG}" = "true" ]; then
   debug="-l debug"
 else
   debug=""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,9 @@ fi
 
 if [ "$debug" = "true" ]; then
   debug="-l debug"
-elif [ "${RUNNER_DEBUG}" = "true" ]; then
+elif [ "${RUNNER_DEBUG}" = "1" ]; then
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
   debug="-l debug"
 else
   debug=""


### PR DESCRIPTION
Resolves #52 
https://okteto.atlassian.net/browse/DEV-320

~~Proposal is to add a new optional input called `debug` where the user can specify to run the workflow using the debug log level~~
Additional to this, Github has the debug logging option when re-runniing a workflow, so the action now recognizes the option enabled and also re-runs adding debug log lever to the flow.

EDIT: input added is `log-level` as an input string at CLI. Valid values are debug, info, warn and error. If value is specified but not valid workflow will fail with error message. If no value is specified, default warn from CLI would be use.

Whenever the workflow is re-run with the debug logging option from dialog enabled, this overrides and uses `debug` level.

Tested by running the action on latest
https://github.com/teresaromero/go-getting-started/actions/workflows/preview.yml

Also you can test this locally using VSCode debug using `bashdb` changing the arguments and envs in order to check the output of the script

```
# .vscode/launch.json
{
    "version": "0.2.0",
    "configurations": [
       {
        "type": "bashdb",
        "pathBash": "/opt/homebrew/bin/bash",
        "request": "launch",
        "name": "Bash-Debug entrypoint.sh",
        "cwd": "${workspaceFolder}",
        "program": "entrypoint.sh",
        "args": [
            "name",
            1,
            "scope",
            "variables",
            "file",
            "branch",
            ""
        ],
        "env": {
            "RUNNER_DEBUG":"0",
        }
       },
    ]
}
```