### PR TITLE
Post different messages per preview

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,7 +88,7 @@ if [ -n "$GITHUB_TOKEN" ]; then
   else
     message=$(/message $name 0)
   fi
-  /notify-pr.sh "$message" $GITHUB_TOKEN
+  /notify-pr.sh "$message" $GITHUB_TOKEN $name
 fi
 
 if [ $ret = 1 ]; then

--- a/message.go
+++ b/message.go
@@ -34,7 +34,7 @@ func main() {
 		return
 	}
 
-	previewURL := fmt.Sprintf("%s/#/previews/%s", oktetoURL, previewName)
+	previewURL := fmt.Sprintf("%s/previews/%s", oktetoURL, previewName)
 
 	var firstLine string
 	if previewCommandExitCode == "0" {

--- a/notify-pr.sh
+++ b/notify-pr.sh
@@ -13,6 +13,7 @@ if !message = ARGV[1]
 end
 
 message = ARGV[0]
+preview_name = ARGV[2]
 repo = ENV["GITHUB_REPOSITORY"]
 
 json = File.read(ENV.fetch("GITHUB_EVENT_PATH"))
@@ -25,7 +26,9 @@ end
 
 github = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
 comments = github.issue_comments(repo, pr)
-comment = comments.find { |c| c["body"].start_with?("Your preview environment") }
+comment = comments.find do |c|
+    c["body"].start_with?("Your preview environment") &&
+    c["body"].include?(preview_name)
 
 if comment
     puts "Message already exists in the PR. Updating"

--- a/notify-pr.sh
+++ b/notify-pr.sh
@@ -28,7 +28,7 @@ github = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
 comments = github.issue_comments(repo, pr)
 comment = comments.find do |c|
     c["body"].start_with?("Your preview environment") &&
-    c["body"].include?(preview_name)
+    c["body"].include?("[#{preview_name}]")
 
 if comment
     puts "Message already exists in the PR. Updating"

--- a/notify-pr.sh
+++ b/notify-pr.sh
@@ -29,6 +29,7 @@ comments = github.issue_comments(repo, pr)
 comment = comments.find do |c|
     c["body"].start_with?("Your preview environment") &&
     c["body"].include?("[#{preview_name}]")
+end
 
 if comment
     puts "Message already exists in the PR. Updating"


### PR DESCRIPTION
When a single PR opens two different previews, the action uses a single message to notify in the PR. This means that the generated message is published by the action finished first, and then overwritten by the following actions, removing the information from the previous ones. This PR fixes this issue by looking for the preview name in the message content.

While on it, I also updated the `/preview/$preview-name` route since it included the `#` which was removed from the okteto UI router system a while ago.