### PR TITLE
Return the value of $ret when no PR number is found

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ okteto preview deploy $name $log_level --scope $scope --branch="${branch}" --rep
 
 if [ -z "$number" ] || [ "$number" = "null" ]; then
   echo "No pull-request defined, skipping notification."
-  exit 0
+  exit $ret
 fi
 
 if [ -n "$GITHUB_TOKEN" ]; then


### PR DESCRIPTION
Thanks to our action to upgrade staging, I realized that we were returning always `0` when the deploy preview is executed outside of a PR lifecycle independently of the result of `okteto preview deploy` command execution. So, if the preview command fails, we were marking the job as successful. 

If the preview command fails, we set `$ret` to be `1`, so this just returns `$ret` instead of 0. I have tested it in a test repo, and it is working correctly. If the command success, the step is marked as success. If the command fails, the step is marked as failure