### PR TITLE
Adds an option for skipping PR notifications

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   log-level:
     description: "Log level string. Valid options are debug, info, warn, error"
     required: false
+  notify-pr:
+    description: "Notify the pull request when the preview environment is created"
+    required: false
+    default: "yes"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -34,6 +38,7 @@ runs:
     - ${{ inputs.file }}
     - ${{ inputs.branch }}
     - ${{ inputs.log-level }}
+    - ${{ inputs.notify-pr}}
 branding:
   color: 'green'
   icon: 'grid'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ variables=$4
 file=$5
 branch=$6
 log_level=$7
+notify_pr=$8
 
 if [ -z $name ]; then
   echo "Preview environment name is required"
@@ -88,7 +89,9 @@ if [ -n "$GITHUB_TOKEN" ]; then
   else
     message=$(/message $name 0)
   fi
-  /notify-pr.sh "$message" $GITHUB_TOKEN $name
+  if [ "${notify_pr}" = "yes" ]; then
+    /notify-pr.sh "$message" $GITHUB_TOKEN $name
+  fi
 fi
 
 if [ $ret = 1 ]; then


### PR DESCRIPTION
In some larger Okteto installations the PR message is either too large (we have 70+ endpoints on a full deploy) or the preview environment is being used for something temporary like integration testing so it won't necessarily still be around when the PR is reviewed.

This adds a flag for notifying the PR that defaults to `yes`, while setting it to anything else such as `no` will skip creating the PR message.