### PR TITLE
Support GitHub Enterprise Server

### DIFF
--- a/notify-pr.sh
+++ b/notify-pr.sh
@@ -24,7 +24,8 @@ else
     pr = event["client_payload"]["pull_request"]["number"]
 end
 
-github = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
+api_endpoint = ENV.fetch("GITHUB_API_URL", "https://api.github.com")
+github = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"], :api_endpoint => api_endpoint)
 comments = github.issue_comments(repo, pr)
 comment = comments.find do |c|
     c["body"].start_with?("Your preview environment") &&


### PR DESCRIPTION
This is an experiment on what it would take to support GHE, not to be merged

## Summary

- Configure the Octokit client in `notify-pr.sh` to use the `GITHUB_API_URL` environment variable instead of hardcoding the GitHub.com API endpoint
- GitHub Actions automatically sets `GITHUB_API_URL` for both GitHub.com (`https://api.github.com`) and GitHub Enterprise Server (`https://<hostname>/api/v3`), so no extra user configuration is required
- `entrypoint.sh` already uses `GITHUB_SERVER_URL` which also works correctly for GHE

## Test plan

- [x] Verify PR comments are posted correctly on GitHub.com (existing behavior unchanged) -> https://github.com/okteto/movies/actions/runs/23265841465/workflow
- [x] Verify PR comments are posted correctly on a GitHub Enterprise Server instance
- [x] Confirm `GITHUB_API_URL` is set to the expected value in both environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

